### PR TITLE
Add conditional include for <cuda/std/tuple> to support CUDA 12.4+

### DIFF
--- a/modules/cudev/include/opencv2/cudev/ptr2d/zip.hpp
+++ b/modules/cudev/include/opencv2/cudev/ptr2d/zip.hpp
@@ -49,7 +49,9 @@
 #include "../common.hpp"
 #include "../util/tuple.hpp"
 #include "traits.hpp"
+#if defined(__CUDACC_VER_MAJOR__) && (__CUDACC_VER_MAJOR__ > 12 || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 4))
 #include <cuda/std/tuple>
+#endif
 
 namespace cv { namespace cudev {
 
@@ -176,6 +178,7 @@ template <class PtrTuple> struct PtrTraits< ZipPtrSz<PtrTuple> > : PtrTraitsBase
 
 }}
 
+#if defined(__CUDACC_VER_MAJOR__) && (__CUDACC_VER_MAJOR__ > 12 || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 4))
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template< class... Types >
@@ -198,3 +201,4 @@ struct tuple_element<N, cv::cudev::ZipPtrSz<tuple<Types...> > >
 _LIBCUDACXX_END_NAMESPACE_STD
 
 #endif
+#enidf


### PR DESCRIPTION
Adds a preprocessor check to conditionally include <cuda/std/tuple>  only for CUDA versions 12.4 and above. This ensures backward compatibility  with older legacy CUDA versions.

Related to pull request #3744

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [ x To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
